### PR TITLE
Some polishing changes

### DIFF
--- a/src/BPGates.jl
+++ b/src/BPGates.jl
@@ -122,12 +122,14 @@ const double_perm_tuple = ((1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 1
 
 function apply_op!(state::BellState, op::BellDoublePermutation)
     phase = state.phases
-    phase_idx = bit_to_int([phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2]])
+    phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
     perm = double_perm_tuple[op.pidx]
     permuted_idx = perm[phase_idx]
     changed_phases = int_to_bit(permuted_idx, Val(4))
-    phase[op.sidx[1]*2-1:op.sidx[1]*2] = changed_phases[1:2]
-    phase[op.sidx[2]*2-1:op.sidx[2]*2] = changed_phases[3:4]
+    phase[op.sidx[1]*2-1] = changed_phases[1]
+    phase[op.sidx[1]*2] = changed_phases[2]
+    phase[op.sidx[2]*2-1] = changed_phases[3]
+    phase[op.sidx[2]*2] = changed_phases[4]
     return state, :continue
 end
 

--- a/src/BPGates.jl
+++ b/src/BPGates.jl
@@ -2,7 +2,12 @@ module BPGates
 
 using QuantumClifford
 
-export int_to_bit, bit_to_int, copy_state, BellState, BellSinglePermutation, BellDoublePermutation, BellPauliPermutation, BellMeasure, BellGateQC, apply_op!, rand_state, stab2qidx, apply_as_qc!, convert2QC
+export BellState,
+    BellSinglePermutation, BellDoublePermutation, BellPauliPermutation,
+    BellMeasure, bellmeasure!,
+    BellGateQC,
+    rand_state,
+    stab2qidx, apply_as_qc!, convert2QC
 
 function int_to_bit(int,digits)
     int = int - 1 # -1 so that we use julia indexing convenctions
@@ -23,38 +28,33 @@ end
 @inline bit_to_int(bit1,bit2) = bit1 ⊻ bit2<<1 + 1 # +1 so that we use julia indexing convenctions
 @inline bit_to_int(bit1,bit2,bit3,bit4) = bit1 ⊻ bit2<<1 ⊻ bit3<<2 ⊻ bit4<<3 + 1 # +1 so that we use julia indexing convenctions
 
-abstract type BellOp end
-
 struct BellState
     phases::BitVector
 end
 
-struct BellPauliPermutation <:BellOp
-    pidx::UInt
+Base.copy(state::BellState) = BellState(copy(state.phases))
+
+abstract type BellOp <: QuantumClifford.AbstractCliffordOperator end
+
+struct BellPauliPermutation <: BellOp
+    pidx::Int
     sidx::Tuple{Int,Int}
 end
 
-struct BellSinglePermutation <:BellOp
-    pidx::UInt
+struct BellSinglePermutation <: BellOp
+    pidx::Int
     sidx::Int
 end
 
-struct BellDoublePermutation <:BellOp
-    pidx::UInt
+struct BellDoublePermutation <: BellOp
+    pidx::Int
     sidx::Tuple{Int,Int}
 end
 
-struct BellMeasure <: BellOp
+struct BellMeasure <: QuantumClifford.AbstractMeasurement
     midx::Int
     sidx::Int
 end
-
-
-##############################
-# Helper functions
-##############################
-
-Base.copy(state::BellState) = BellState(copy(state.phases))
 
 ##############################
 # Permutations
@@ -68,7 +68,8 @@ const one_perm_tuple = (
     (2, 3, 1, 4),
     (2, 1, 3, 4)
 )
-function apply_op!(state::BellState, op::BellSinglePermutation)
+
+function QuantumClifford.apply!(state::BellState, op::BellSinglePermutation)
     phase = state.phases
     @inbounds phase_idx = bit_to_int(phase[op.sidx*2-1],phase[op.sidx*2])
     @inbounds perm = one_perm_tuple[op.pidx]
@@ -86,7 +87,7 @@ const pauli_perm_tuple = (
     (4, 3, 2, 1, 8, 7, 6, 5, 12, 11, 10, 9, 16, 15, 14, 13)
 )
 
-function apply_op!(state::BellState, op::BellPauliPermutation)
+function QuantumClifford.apply!(state::BellState, op::BellPauliPermutation)
     phase = state.phases
     @inbounds phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
     @inbounds perm = pauli_perm_tuple[op.pidx]
@@ -99,28 +100,30 @@ function apply_op!(state::BellState, op::BellPauliPermutation)
     return state
 end
 
-const double_perm_tuple = ((1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 16),
-(1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16),
-(1, 2, 11, 12, 6, 5, 16, 15, 9, 10, 3, 4, 14, 13, 8, 7),
-(1, 3, 10, 12, 7, 5, 16, 14, 9, 11, 2, 4, 15, 13, 8, 6),
-(1, 9, 7, 15, 10, 2, 16, 8, 3, 11, 5, 13, 12, 4, 14, 6),
-(1, 3, 6, 8, 5, 7, 2, 4, 11, 9, 16, 14, 15, 13, 12, 10),
-(9, 11, 6, 8, 5, 7, 10, 12, 3, 1, 16, 14, 15, 13, 4, 2),
-(1, 10, 11, 4, 16, 7, 6, 13, 9, 2, 3, 12, 8, 15, 14, 5),
-(1, 11, 5, 15, 6, 16, 2, 12, 3, 9, 7, 13, 8, 14, 4, 10),
-(1, 11, 7, 13, 16, 6, 10, 4, 3, 9, 5, 15, 14, 8, 12, 2),
-(1, 9, 6, 14, 2, 10, 5, 13, 11, 3, 16, 8, 12, 4, 15, 7),
-(3, 11, 6, 14, 2, 10, 7, 15, 9, 1, 16, 8, 12, 4, 13, 5),
-(1, 7, 2, 8, 5, 3, 6, 4, 10, 16, 9, 15, 14, 12, 13, 11),
-(3, 5, 2, 8, 7, 1, 6, 4, 10, 16, 11, 13, 14, 12, 15, 9),
-(1, 5, 10, 14, 7, 3, 16, 12, 2, 6, 9, 13, 8, 4, 15, 11),
-(3, 7, 10, 14, 5, 1, 16, 12, 2, 6, 11, 15, 8, 4, 13, 9),
-(9, 2, 5, 14, 10, 1, 6, 13, 7, 16, 11, 4, 8, 15, 12, 3),
-(9, 10, 7, 8, 2, 1, 16, 15, 5, 6, 11, 12, 14, 13, 4, 3),
-(9, 7, 6, 12, 5, 11, 10, 8, 16, 2, 3, 13, 4, 14, 15, 1),
-(10, 6, 3, 15, 5, 9, 16, 4, 11, 7, 2, 14, 8, 12, 13, 1))
+const double_perm_tuple = (
+    (1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 16),
+    (1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16),
+    (1, 2, 11, 12, 6, 5, 16, 15, 9, 10, 3, 4, 14, 13, 8, 7),
+    (1, 3, 10, 12, 7, 5, 16, 14, 9, 11, 2, 4, 15, 13, 8, 6),
+    (1, 9, 7, 15, 10, 2, 16, 8, 3, 11, 5, 13, 12, 4, 14, 6),
+    (1, 3, 6, 8, 5, 7, 2, 4, 11, 9, 16, 14, 15, 13, 12, 10),
+    (9, 11, 6, 8, 5, 7, 10, 12, 3, 1, 16, 14, 15, 13, 4, 2),
+    (1, 10, 11, 4, 16, 7, 6, 13, 9, 2, 3, 12, 8, 15, 14, 5),
+    (1, 11, 5, 15, 6, 16, 2, 12, 3, 9, 7, 13, 8, 14, 4, 10),
+    (1, 11, 7, 13, 16, 6, 10, 4, 3, 9, 5, 15, 14, 8, 12, 2),
+    (1, 9, 6, 14, 2, 10, 5, 13, 11, 3, 16, 8, 12, 4, 15, 7),
+    (3, 11, 6, 14, 2, 10, 7, 15, 9, 1, 16, 8, 12, 4, 13, 5),
+    (1, 7, 2, 8, 5, 3, 6, 4, 10, 16, 9, 15, 14, 12, 13, 11),
+    (3, 5, 2, 8, 7, 1, 6, 4, 10, 16, 11, 13, 14, 12, 15, 9),
+    (1, 5, 10, 14, 7, 3, 16, 12, 2, 6, 9, 13, 8, 4, 15, 11),
+    (3, 7, 10, 14, 5, 1, 16, 12, 2, 6, 11, 15, 8, 4, 13, 9),
+    (9, 2, 5, 14, 10, 1, 6, 13, 7, 16, 11, 4, 8, 15, 12, 3),
+    (9, 10, 7, 8, 2, 1, 16, 15, 5, 6, 11, 12, 14, 13, 4, 3),
+    (9, 7, 6, 12, 5, 11, 10, 8, 16, 2, 3, 13, 4, 14, 15, 1),
+    (10, 6, 3, 15, 5, 9, 16, 4, 11, 7, 2, 14, 8, 12, 13, 1)
+)
 
-function apply_op!(state::BellState, op::BellDoublePermutation)
+function QuantumClifford.apply!(state::BellState, op::BellDoublePermutation)
     phase = state.phases
     @inbounds phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
     @inbounds perm = double_perm_tuple[op.pidx]
@@ -137,16 +140,18 @@ end
 # Measurements
 ##############################
 
-const measure_tuple = ((true, true, true),
-(false, false, true),
-(true, false, false),
-(false, true, false))
+const measure_tuple = (
+    (true, true, true),
+    (false, false, true),
+    (true, false, false),
+    (false, true, false)
+)
 
-function apply_op!(state::BellState, op::BellMeasure)
+function bellmeasure!(state::BellState, op::BellMeasure)
     phase = state.phases
     result = measure_tuple[bit_to_int(phase[op.sidx*2-1],phase[op.sidx*2])][op.midx]
     phase[op.sidx*2-1:op.sidx*2] .= 0 # reset the measured pair to 00
-    return state, result ? :continue : :detected_error
+    return state, result
 end
 
 ##############################
@@ -162,21 +167,12 @@ struct BellGateQC
     idx2::Int
 end
 
-function apply_op!(state, g::BellGateQC)
-    apply_op!(state, BellPauliPermutation(g.pauli,(g.idx1,g.idx2)))
-    apply_op!(state, BellDoublePermutation(g.double,(g.idx1,g.idx2)))
-    apply_op!(state, BellSinglePermutation(g.single1,g.idx1))
-    apply_op!(state, BellSinglePermutation(g.single2,g.idx2))
+function QuantumClifford.apply!(state, g::BellGateQC)
+    apply!(state, BellPauliPermutation(g.pauli,(g.idx1,g.idx2)))
+    apply!(state, BellDoublePermutation(g.double,(g.idx1,g.idx2)))
+    apply!(state, BellSinglePermutation(g.single1,g.idx1))
+    apply!(state, BellSinglePermutation(g.single2,g.idx2))
     return state
-end
-
-function apply_op!(state,circuit)
-    for op in circuit
-        if apply_op!(state,op)[end]==:detected_error
-            return state, :detected_error
-        end
-    end
-    return state, :continue
 end
 
 ##############################
@@ -185,35 +181,39 @@ end
 
 stab2qidx(stab)=isone.(stab.phases.÷0x2)
 
-const one_perm_qc = (C"X Z",
-C"Z X",
-C"Y X",
-C"X Y",
-C"Z Y",
-C"Y Z");
+const one_perm_qc = (
+    C"X Z",
+    C"Z X",
+    C"Y X",
+    C"X Y",
+    C"Z Y",
+    C"Y Z"
+)
 
-const two_perm_qc = (C"X_ _Z Z_ _X",
-C"_X X_ _Z Z_",
-C"XX _X Z_ ZZ",
-C"ZX _X X_ XZ",
-C"XZ X_ _X ZX",
-C"ZZ XX X_ _Z",
-C"ZY XX X_ _Y",
-C"XX _X ZX YY",
-C"_Z X_ XX ZZ",
-C"XZ X_ XX YY",
-C"ZZ XX _X Z_",
-C"YZ XX _X Y_",
-C"Z_ ZX XZ _Z",
-C"Y_ YX XZ _Z",
-C"ZX Z_ _Z XZ",
-C"YX Y_ _Z XZ",
-C"_Y XY ZX Z_",
-C"XY _Y Z_ ZX",
-C"ZY YZ XY _Y",
-C"YX Y_ _Y ZY");
+const two_perm_qc = (
+    C"X_ _Z Z_ _X",
+    C"_X X_ _Z Z_",
+    C"XX _X Z_ ZZ",
+    C"ZX _X X_ XZ",
+    C"XZ X_ _X ZX",
+    C"ZZ XX X_ _Z",
+    C"ZY XX X_ _Y",
+    C"XX _X ZX YY",
+    C"_Z X_ XX ZZ",
+    C"XZ X_ XX YY",
+    C"ZZ XX _X Z_",
+    C"YZ XX _X Y_",
+    C"Z_ ZX XZ _Z",
+    C"Y_ YX XZ _Z",
+    C"ZX Z_ _Z XZ",
+    C"YX Y_ _Z XZ",
+    C"_Y XY ZX Z_",
+    C"XY _Y Z_ ZX",
+    C"ZY YZ XY _Y",
+    C"YX Y_ _Y ZY"
+)
 
-const pauli_perm_qc = (P"II",P"XI",P"ZI",P"YI");
+const pauli_perm_qc = (P"II",P"XI",P"ZI",P"YI")
 
 function rand_state(num_bell)  # TODO this would fail above 32 Bell pairs
     return BellState(int_to_bit(rand(1:4^num_bell),num_bell*2))
@@ -236,6 +236,7 @@ function convert2QC(state::BellState)
     res.phases .= state.phases*0x2
     return res
 end
+
 function convert2BP(state::Stabilizer)
     return BellState(stab2qidx(state))
 end
@@ -249,7 +250,6 @@ function apply_as_qc!(state::BellState, gate::BellGateQC)
     state.phases .= new_phases
     return state, :continue
 end
-
 
 function apply_as_qc!(state::BellState, gate::BellMeasure)
     phases = state.phases[:]

--- a/src/BPGates.jl
+++ b/src/BPGates.jl
@@ -70,13 +70,13 @@ const one_perm_tuple = (
 )
 function apply_op!(state::BellState, op::BellSinglePermutation)
     phase = state.phases
-    phase_idx = bit_to_int(phase[op.sidx*2-1],phase[op.sidx*2])
-    perm = one_perm_tuple[op.pidx]
-    permuted_idx = perm[phase_idx]
+    @inbounds phase_idx = bit_to_int(phase[op.sidx*2-1],phase[op.sidx*2])
+    @inbounds perm = one_perm_tuple[op.pidx]
+    @inbounds permuted_idx = perm[phase_idx]
     bit1, bit2 = int_to_bit(permuted_idx,Val(2))
-    phase[op.sidx*2-1] = bit1
-    phase[op.sidx*2] = bit2
-    return state, :continue
+    @inbounds phase[op.sidx*2-1] = bit1
+    @inbounds phase[op.sidx*2] = bit2
+    return state
 end
 
 const pauli_perm_tuple = (
@@ -88,15 +88,15 @@ const pauli_perm_tuple = (
 
 function apply_op!(state::BellState, op::BellPauliPermutation)
     phase = state.phases
-    phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
-    perm = pauli_perm_tuple[op.pidx]
-    permuted_idx = perm[phase_idx]
+    @inbounds phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
+    @inbounds perm = pauli_perm_tuple[op.pidx]
+    @inbounds permuted_idx = perm[phase_idx]
     changed_phases = int_to_bit(permuted_idx, Val(4))
-    phase[op.sidx[1]*2-1] = changed_phases[1]
-    phase[op.sidx[1]*2] = changed_phases[2]
-    phase[op.sidx[2]*2-1] = changed_phases[3]
-    phase[op.sidx[2]*2] = changed_phases[4]
-    return state, :continue
+    @inbounds phase[op.sidx[1]*2-1] = changed_phases[1]
+    @inbounds phase[op.sidx[1]*2] = changed_phases[2]
+    @inbounds phase[op.sidx[2]*2-1] = changed_phases[3]
+    @inbounds phase[op.sidx[2]*2] = changed_phases[4]
+    return state
 end
 
 const double_perm_tuple = ((1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 16),
@@ -122,15 +122,15 @@ const double_perm_tuple = ((1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 1
 
 function apply_op!(state::BellState, op::BellDoublePermutation)
     phase = state.phases
-    phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
-    perm = double_perm_tuple[op.pidx]
-    permuted_idx = perm[phase_idx]
+    @inbounds phase_idx = bit_to_int(phase[op.sidx[1]*2-1],phase[op.sidx[1]*2],phase[op.sidx[2]*2-1], phase[op.sidx[2]*2])
+    @inbounds perm = double_perm_tuple[op.pidx]
+    @inbounds permuted_idx = perm[phase_idx]
     changed_phases = int_to_bit(permuted_idx, Val(4))
-    phase[op.sidx[1]*2-1] = changed_phases[1]
-    phase[op.sidx[1]*2] = changed_phases[2]
-    phase[op.sidx[2]*2-1] = changed_phases[3]
-    phase[op.sidx[2]*2] = changed_phases[4]
-    return state, :continue
+    @inbounds phase[op.sidx[1]*2-1] = changed_phases[1]
+    @inbounds phase[op.sidx[1]*2] = changed_phases[2]
+    @inbounds phase[op.sidx[2]*2-1] = changed_phases[3]
+    @inbounds phase[op.sidx[2]*2] = changed_phases[4]
+    return state
 end
 
 ##############################
@@ -167,7 +167,7 @@ function apply_op!(state, g::BellGateQC)
     apply_op!(state, BellDoublePermutation(g.double,(g.idx1,g.idx2)))
     apply_op!(state, BellSinglePermutation(g.single1,g.idx1))
     apply_op!(state, BellSinglePermutation(g.single2,g.idx2))
-    return state, :continue
+    return state
 end
 
 function apply_op!(state,circuit)


### PR DESCRIPTION
Hi, Shu,

I removed a few more list allocations, and one or two functions became much faster. I think this is as optimized as we will get it for a while.

I have started renaming some functions so they match the QuantumClifford API better.

Could you review/merge this pull request?

Could you also do the following:

- Implement convert2QC for all gate types you have created, not just the compound one.
- Fill in the documentation strings I have marked with `TODO docs`. For structures, put in a title and about a paragraph or two explaining the structure and its limits and its reasons for existence. For functions feel free to just put in a title and nothing else.